### PR TITLE
Change callback to .then

### DIFF
--- a/Configs.js
+++ b/Configs.js
@@ -161,7 +161,7 @@ class Configs {
     const update = {};
     update[aKey] = aValue;
     try {
-      browser.storage.local.set(update, () => {
+      browser.storage.local.set(update).then(() => {
         this._log('successfully saved', update);
       });
     }
@@ -170,7 +170,7 @@ class Configs {
     }
     try {
       if (this._syncKeys.includes(aKey))
-        browser.storage.sync.set(update, () => {
+        browser.storage.sync.set(update).then(() => {
           this._log('successfully synced', update);
         });
     }


### PR DESCRIPTION
The callback breaks the webextension polyfill on Chrome, and I believe this is how it should be.

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set