### PR TITLE
FIx "could not establish connection" error on _tryload()

### DIFF
--- a/Configs.js
+++ b/Configs.js
@@ -154,7 +154,7 @@ class Configs {
       this._log('load: values are applied');
 
       for (const key of new Set(lockedKeys)) {
-        this._updateLocked(key, true);
+        this._updateLocked(key, true, { broadcast: false });
       }
       this._log('load: locked state is applied');
       browser.storage.onChanged.addListener(this._onChanged.bind(this));


### PR DESCRIPTION
At this point of the code, no listener is registered. For this reason,
this line causes the following exception:

> error: could not establish connection. receiving end does not exist

Fix this issue by avoid broadcasting on initial loading.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>