### PR TITLE
Do not enforce timeout except on thunderbird

### DIFF
--- a/Configs.js
+++ b/Configs.js
@@ -86,8 +86,6 @@ class Configs {
           }
           let resolved = false;
           return new Promise((resolve, _reject) => {
-            // storage.managed.get() fails on options page in Thunderbird.
-            // The problem should be fixed by Thunderbird side.
             browser.storage.managed.get().then(managedValues => {
               if (resolved)
                 return;
@@ -101,13 +99,18 @@ class Configs {
               this._log('load: failed to load managed storage: ', String(error));
               resolve(null);
             });
-            setTimeout(() => {
-              if (resolved)
-                return;
-              resolved = true;
-              this._log('load: failed to load managed storage: timeout');
-              resolve(null);
-            }, 250);
+
+            // storage.managed.get() fails on options page in Thunderbird.
+            // The problem should be fixed by Thunderbird side.
+            if (window.messenger) {
+                setTimeout(() => {
+                  if (resolved)
+                    return;
+                  resolved = true;
+                  this._log('load: failed to load managed storage: timeout');
+                  resolve(null);
+                }, 250);
+            }
           });
         })(),
         (async () => {


### PR DESCRIPTION
Evidently this code is causing the issue "the managed setting is
not reliably loaded on Google Chrome".

Avoid that issue by disbling the timeout except on Thunderbird
(which is the platfrom that particular code is for).

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>